### PR TITLE
Fix cycling update.

### DIFF
--- a/src/app/editors/RefCheck.java
+++ b/src/app/editors/RefCheck.java
@@ -23,6 +23,8 @@ public class RefCheck {
 				return;
 			RefSync.updateRefs(ds, App.index());
 			Data.updateVersion(ds);
+			// Update the version of the self reference after, to avoid loops.
+			RefSync.updateSelfRefVersion(ds);
 			Data.save(ds);
 			Ref ref = Ref.of(ds);
 			Editors.close(ref);

--- a/src/app/store/Data.java
+++ b/src/app/store/Data.java
@@ -128,8 +128,7 @@ public final class Data {
 	}
 
 	public static void updateVersion(IDataSet ds) {
-		if (ds instanceof Process) {
-			Process p = (Process) ds;
+		if (ds instanceof Process p) {
 			with(Processes.forcePublication(p), pub -> {
 				pub.version = Version.fromString(pub.version)
 						.incUpdate().toString();
@@ -137,8 +136,7 @@ public final class Data {
 			Processes.forceDataEntry(p).timeStamp = Xml.now();
 		}
 
-		if (ds instanceof Flow) {
-			Flow f = (Flow) ds;
+		if (ds instanceof Flow f) {
 			with(Flows.publication(f), pub -> {
 				pub.version = Version.fromString(pub.version)
 						.incUpdate().toString();
@@ -146,8 +144,7 @@ public final class Data {
 			Flows.dataEntry(f).timeStamp = Xml.now();
 		}
 
-		if (ds instanceof FlowProperty) {
-			FlowProperty fp = (FlowProperty) ds;
+		if (ds instanceof FlowProperty fp) {
 			with(FlowProperties.publication(fp), pub -> {
 				pub.version = Version.fromString(pub.version)
 						.incUpdate().toString();
@@ -155,8 +152,7 @@ public final class Data {
 			FlowProperties.dataEntry(fp).timeStamp = Xml.now();
 		}
 
-		if (ds instanceof UnitGroup) {
-			UnitGroup ug = (UnitGroup) ds;
+		if (ds instanceof UnitGroup ug) {
 			with(UnitGroups.publication(ug), pub -> {
 				pub.version = Version.fromString(pub.version)
 						.incUpdate().toString();
@@ -164,8 +160,7 @@ public final class Data {
 			UnitGroups.dataEntry(ug).timeStamp = Xml.now();
 		}
 
-		if (ds instanceof Contact) {
-			Contact c = (Contact) ds;
+		if (ds instanceof Contact c) {
 			with(Contacts.publication(c), pub -> {
 				pub.version = Version.fromString(pub.version)
 						.incUpdate().toString();
@@ -173,8 +168,7 @@ public final class Data {
 			Contacts.dataEntry(c).timeStamp = Xml.now();
 		}
 
-		if (ds instanceof Source) {
-			Source s = (Source) ds;
+		if (ds instanceof Source s) {
 			with(Sources.publication(s), pub -> {
 				pub.version = Version.fromString(pub.version)
 						.incUpdate().toString();
@@ -182,8 +176,7 @@ public final class Data {
 			Sources.dataEntry(s).timeStamp = Xml.now();
 		}
 
-		if (ds instanceof LCIAMethod) {
-			LCIAMethod l = (LCIAMethod) ds;
+		if (ds instanceof LCIAMethod l) {
 			with(Methods.forcePublication(l), pub -> {
 				pub.version = Version.fromString(pub.version)
 						.incUpdate().toString();

--- a/src/epd/index/RefSync.java
+++ b/src/epd/index/RefSync.java
@@ -44,6 +44,18 @@ public final class RefSync {
 		});
 	}
 
+	public static void updateSelfRefVersion(IDataSet ds) {
+		if (ds == null)
+			return;
+		var selfRef = RefTree.create(ds).getRefs().stream()
+				.filter(ref -> ref.uuid.equals(ds.getUUID()))
+				.findFirst()
+				.orElse(null);
+		if (selfRef == null)
+			return;
+		selfRef.version = ds.getVersion();
+	}
+	
 	private static boolean isNewer(Ref indexRef, Ref than) {
 		if (indexRef == null || than == null)
 			return false;


### PR DESCRIPTION
The update was cycling when a dataset is self-referencing. The reference version was bumped before the dataset version. Thus, it was always one step below after the update.